### PR TITLE
Optional prefetches

### DIFF
--- a/include/hashinator/hashinator.h
+++ b/include/hashinator/hashinator.h
@@ -823,8 +823,8 @@ namespace Hashinator{
       
       #ifndef HASHINATOR_HOST_ONLY
       //Pass memAdvice to hashinator and the underlying splitvector
-      HOSTONLY void memAdvise(cudaMemoryAdvise advice,int device ){
-         buckets.memAdvise(advice,device);
+      HOSTONLY void memAdvise(cudaMemoryAdvise advice,int device,cudaStream_t stream=0){
+         buckets.memAdvise(advice,device,stream);
          cudaMemAdvise( _mapInfo,sizeof(MapInfo) , advice, device ) ;
       }
 

--- a/include/splitvector/splitvec.h
+++ b/include/splitvector/splitvec.h
@@ -308,9 +308,10 @@ namespace split{
          }
 
          //Pass memAdvice direcitves to the data.
-         HOSTONLY void memAdvise(cudaMemoryAdvise advice,int device ){
-            int device;
-            cudaGetDevice(&device);
+         HOSTONLY void memAdvise(cudaMemoryAdvise advice,int device=-1,cudaStream_t stream=0){
+            if (device==-1) {
+               cudaGetDevice(&device);
+            }
             cudaMemPrefetchAsync(_capacity,sizeof(size_t),cudaCpuDeviceId,stream);
             cudaStreamSynchronize(stream);
             cudaMemAdvise( _data, capacity()*sizeof(T), advice, device ) ;


### PR DESCRIPTION
Prefetches incur an overhead, so made some of them optional (default is still on)
Placed some destructor calls inside is_pod checks.
Other minor fixes.