### PR TITLE
Device resize does not construct elements unless necessary.

### DIFF
--- a/include/hashinator/hashinator.h
+++ b/include/hashinator/hashinator.h
@@ -577,11 +577,11 @@ public:
 #else
    // Try to get the overflow back to the original one
    void performCleanupTasks(split_gpuStream_t s = 0) {
+      if (tombstone_ratio() > 0.125) {
+         clean_tombstones(s);
+      }
       while (_mapInfo->currentMaxBucketOverflow > Hashinator::defaults::BUCKET_OVERFLOW) {
          device_rehash(_mapInfo->sizePower + 1, s);
-      }
-      if (tombstone_ratio() > 0.025) {
-         clean_tombstones(s);
       }
    }
 

--- a/include/hashinator/hashinator.h
+++ b/include/hashinator/hashinator.h
@@ -583,7 +583,7 @@ public:
 #else
    // Try to get the overflow back to the original one
    void performCleanupTasks(split_gpuStream_t s = 0) {
-      if (tombstone_ratio() > 0.125) {
+      if (tombstone_ratio() > 0.025) {
          clean_tombstones(s);
       }
       while (_mapInfo->currentMaxBucketOverflow > Hashinator::defaults::BUCKET_OVERFLOW) {

--- a/include/hashinator/hashinator.h
+++ b/include/hashinator/hashinator.h
@@ -257,7 +257,7 @@ public:
       _mapInfo->currentMaxBucketOverflow = Hashinator::defaults::BUCKET_OVERFLOW;
       _mapInfo->tombstoneCounter = 0;
       #ifndef HASHINATOR_CPU_ONLY_MODE
-      SPLIT_CHECK_ERR(split_gpuMemcpyAsync(device_map, this, sizeof(Hashmap), split_gpuMemcpyHostToDevice, stream));
+      SPLIT_CHECK_ERR(split_gpuMemcpy(device_map, this, sizeof(Hashmap), split_gpuMemcpyHostToDevice));
       #endif
    }
 
@@ -603,12 +603,13 @@ public:
    }
 #else
    // Try to get the overflow back to the original one
+   template <bool prefetches = true>
    void performCleanupTasks(split_gpuStream_t s = 0) {
       if (tombstone_ratio() > 0.025) {
-         clean_tombstones(s);
+         clean_tombstones<prefetches>(s);
       }
       while (_mapInfo->currentMaxBucketOverflow > Hashinator::defaults::BUCKET_OVERFLOW) {
-         device_rehash(_mapInfo->sizePower + 1, s);
+         device_rehash<prefetches>(_mapInfo->sizePower + 1, s);
       }
    }
 

--- a/include/splitvector/split_tools.h
+++ b/include/splitvector/split_tools.h
@@ -1005,7 +1005,7 @@ void copy_if_loop(
    split::SplitVector<T, split::split_unified_allocator<T>>& input,
    split::SplitVector<T, split::split_unified_allocator<T>>& output,
    Rule rule, split_gpuStream_t s = 0) {
-   #ifndef NDEBUG
+   #ifdef HASHINATOR_DEBUG
    bool input_ok = isDeviceAccessible( reinterpret_cast<void*>(&input));
    bool output_ok= isDeviceAccessible( reinterpret_cast<void*>(&output));
    assert( (input_ok && output_ok) && "This method supports splitvectors dynamically allocated on device or unified memory!");
@@ -1018,7 +1018,7 @@ void copy_if_keys_loop(
    split::SplitVector<T, split::split_unified_allocator<T>>& input,
    split::SplitVector<U, split::split_unified_allocator<U>>& output,
    Rule rule, split_gpuStream_t s = 0) {
-   #ifndef NDEBUG
+   #ifdef HASHINATOR_DEBUG
    bool input_ok = isDeviceAccessible( reinterpret_cast<void*>(&input));
    bool output_ok= isDeviceAccessible( reinterpret_cast<void*>(&output));
    assert( (input_ok && output_ok) && "This method supports splitvectors dynamically allocated on device or unified memory!");

--- a/include/splitvector/splitvec.h
+++ b/include/splitvector/splitvec.h
@@ -392,8 +392,11 @@ public:
       if constexpr (std::is_trivially_copyable<T>::value) {
             if (other._location == Residency::device) {
                _location = Residency::device;
-               //optimizeGPU(stream);
                SPLIT_CHECK_ERR(split_gpuMemcpyAsync(_data, other._data, size() * sizeof(T), split_gpuMemcpyDeviceToDevice,stream));
+               int device;
+               SPLIT_CHECK_ERR(split_gpuGetDevice(&device));
+               SPLIT_CHECK_ERR(split_gpuMemPrefetchAsync(_size, sizeof(size_t), device, stream));
+               SPLIT_CHECK_ERR(split_gpuMemPrefetchAsync(_capacity, sizeof(size_t), device, stream));
                return;
             }
          }


### PR DESCRIPTION
also:
 More standard implementation of `device_buckets` and `d_vec` inside splitvector
 changed the `prefetches` flag to be a templated parameter instead of a function parameter
 page fault improvement to loop accessors
 optimized `device_rehash` when retaining same buckets size

A Vlasiator testpackage run with these changes included is queued, let's see what Hashinator's CI says.